### PR TITLE
Convert to modern SDK-style project

### DIFF
--- a/BidFX.Public.API.Example/BidFX.Public.API.Example.csproj
+++ b/BidFX.Public.API.Example/BidFX.Public.API.Example.csproj
@@ -1,82 +1,40 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5C8CA288-1771-4ED0-A3AB-8A234523379F}</ProjectGuid>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BidFX.Public.API.Example</RootNamespace>
-    <AssemblyName>BidFX.Public.API.Example</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net471</TargetFramework>
     <LangVersion>4</LangVersion>
+    <AssemblyTitle>BidFX.Public.NAPI.Example</AssemblyTitle>
+    <Company>BidFX Limited</Company>
+    <Product>BidFX.Public.NAPIClient.Example</Product>
+    <Copyright>Copyright ©  2017</Copyright>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.Sinks.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.Console.4.0.0-dev-00839\lib\net45\Serilog.Sinks.Console.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ApiExample.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TopOfBookExample.cs" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Data.DataSetExtensions" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\BidFX.Public.API\BidFX.Public.API.csproj">
-      <Project>{096edeb7-9912-45bc-9c51-a7e871e58c4e}</Project>
-      <Name>BidFX.Public.API</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\BidFX.Public.API\BidFX.Public.API.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/BidFX.Public.API.Example/Properties/AssemblyInfo.cs
+++ b/BidFX.Public.API.Example/Properties/AssemblyInfo.cs
@@ -1,21 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyVersion("1.0.2")]
-[assembly: AssemblyFileVersion("1.0.2")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyCompany("BidFX Limited")]
-[assembly: AssemblyTitle("BidFX.Public.NAPI.Example")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("BidFX.Public.NAPIClient.Example")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.

--- a/BidFX.Public.API.Example/packages.config
+++ b/BidFX.Public.API.Example/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Serilog" version="2.10.0" targetFramework="net471" />
-  <package id="Serilog.Sinks.Console" version="4.0.0-dev-00839" targetFramework="net471" />
-</packages>

--- a/BidFX.Public.API.Test/BidFX.Public.API.Test.csproj
+++ b/BidFX.Public.API.Test/BidFX.Public.API.Test.csproj
@@ -1,137 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{FC6653D6-3A62-444C-B074-5CF88C1690B6}</ProjectGuid>
-        <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>BidFX.Public.API.Test</RootNamespace>
-        <AssemblyName>BidFX.Public.API.Test</AssemblyName>
-        <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
-          <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920">
-          <HintPath>..\packages\Moq.4.13.1\lib\net45\Moq.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="System.Configuration" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-          <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-          <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
-          <Private>True</Private>
-        </Reference>
-        <Reference Include="System.Xml" />
-        <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-            <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="test\Enums\FxTenorTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\AckDataTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Fields\DataDictionaryUtilsTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Fields\ExtendableDataDictionaryTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Fields\FieldEncodingTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Fields\FieldTypeTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\AckMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\ControlOperationTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\DataDictionaryMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\GrantMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\GridColumnTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\GridTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\HeartbeatMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\LoginMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\PixieMessageTypeTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\PriceStatusCodecTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\PriceSyncTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\PriceUpdateDecoderTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\SubscriptionSyncTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\Messages\WelcomeMessageTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\PixieSubjectValidatorTest.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\RealSubscriptionExample.cs" />
-        <Compile Include="test\Price\Plugin\Pixie\SubjectSetRegisterTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\FieldExtractorTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\MessageFormatterTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\PriceAdaptorTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\PuffinElementTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\PuffinMessageReaderTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\TokenDictionaryTest.cs" />
-        <Compile Include="test\Price\Plugin\Puffin\ValueParserTest.cs" />
-        <Compile Include="test\Price\PriceMapTest.cs" />
-        <Compile Include="test\Price\Subject\CommonComponentsTest.cs" />
-        <Compile Include="test\Price\Subject\CommonSubjectsTest.cs" />
-        <Compile Include="test\Price\Subject\RequestSubjectComparatorTest.cs" />
-        <Compile Include="test\Price\Subject\SubjectBuilderTest.cs" />
-        <Compile Include="test\Price\Subject\SubjectFormatterTest.cs" />
-        <Compile Include="test\Price\Subject\SubjectIteratorTest.cs" />
-        <Compile Include="test\Price\Subject\SubjectTest.cs" />
-        <Compile Include="test\Price\Subject\SubjectValidatorTest.cs" />
-        <Compile Include="test\Price\Subject\SubscriptionSetTest.cs" />
-        <Compile Include="test\Tools\BitSetterTest.cs" />
-        <Compile Include="test\Tools\NameCacheTest.cs" />
-        <Compile Include="test\Tools\NumericCharacterEntityTest.cs" />
-        <Compile Include="test\Tools\ParamsTest.cs" />
-        <Compile Include="test\Tools\VarintTest.cs" />
-        <Compile Include="test\Tools\WebServer.cs" />
-        <Compile Include="test\Trade\Instruction\OrderAmendBuilderTest.cs" />
-        <Compile Include="test\Trade\Instruction\OrderCancelBuilderTest.cs" />
-        <Compile Include="test\Trade\Instruction\OrderSubmitBuilderTest.cs" />
-        <Compile Include="test\Trade\Order\AllocationTemplateEntryBuilderTest.cs" />
-        <Compile Include="test\Trade\Order\FutureOrderBuilderTest.cs" />
-        <Compile Include="test\Trade\Order\FxOrderBuilderTest.cs" />
-        <Compile Include="test\Trade\Order\OrderBuilderTest.cs" />
-        <Compile Include="test\Trade\Rest\Json\JsonMarshallerTest.cs" />
-        <Compile Include="test\Trade\SettlementDateResponseTest.cs" />
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\BidFX.Public.API\BidFX.Public.API.csproj">
-        <Project>{096edeb7-9912-45bc-9c51-a7e871e58c4e}</Project>
-        <Name>BidFX.Public.API</Name>
-      </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-      <None Include="packages.config" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-         Other similar extension points exist, see Microsoft.Common.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-    -->
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{FC6653D6-3A62-444C-B074-5CF88C1690B6}</ProjectGuid>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFramework>net471</TargetFramework>
+    <AssemblyTitle>BidFX.Public.API.Test</AssemblyTitle>
+    <Product>BidFX.Public.API.Test</Product>
+    <Copyright>Copyright ©  2020</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BidFX.Public.API\BidFX.Public.API.csproj" />
+  </ItemGroup>
 </Project>

--- a/BidFX.Public.API.Test/Properties/AssemblyInfo.cs
+++ b/BidFX.Public.API.Test/Properties/AssemblyInfo.cs
@@ -1,18 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("BidFX.Public.API.Test")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BidFX.Public.API.Test")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -20,16 +8,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("FC6653D6-3A62-444C-B074-5CF88C1690B6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BidFX.Public.API.Test/packages.config
+++ b/BidFX.Public.API.Test/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
-  <package id="Moq" version="4.13.1" targetFramework="net471" />
-  <package id="NUnit" version="3.5.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net471" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
-</packages>

--- a/BidFX.Public.API/BidFX.Public.API.csproj
+++ b/BidFX.Public.API/BidFX.Public.API.csproj
@@ -1,29 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Obfuscar.2.2.12\build\obfuscar.props" Condition="Exists('..\packages\Obfuscar.2.2.12\build\obfuscar.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{096EDEB7-9912-45BC-9C51-A7E871E58C4E}</ProjectGuid>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BidFX.Public.API</RootNamespace>
-    <AssemblyName>BidFX.Public.API</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net471</TargetFramework>
     <LangVersion>4</LangVersion>
+    <AssemblyTitle>BidFX.Public.API</AssemblyTitle>
+    <Company>BidFX Limited</Company>
+    <Product>BidFX.Public.API</Product>
+    <Copyright>Copyright © 2018</Copyright>
+    <AssemblyVersion>1.7.3</AssemblyVersion>
+    <FileVersion>1.7.3</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,184 +21,32 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Pre-Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PostBuildEvent>
+      "$(Obfuscar)" "$(MSBuildThisFileDirectory)obfuscar.xml"
+      mkdir "..\BidFX.Public.API"
+      copy "..\Obfuscator_Output\BidFX.Public.API.dll" "..\BidFX.Public.API\BidFX.Public.API.dll" /Y
+      copy "DotNetZip.dll" "..\BidFX.Public.API\DotNetZip.dll" /Y
+      copy "Serilog.dll" "..\BidFX.Public.API\Serilog.dll" /Y
+    </PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zlib, Version=1.9.1.5, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>bin\Debug\Ionic.Zlib.dll</HintPath>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.Bcl" Version="1.1.10" />
+    <PackageReference Include="Obfuscar" Version="2.2.12">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="src\Client.cs" />
-    <Compile Include="src\DefaultClient.cs" />
-    <Compile Include="src\Enums\FxTenor.cs" />
-    <Compile Include="src\IllegalStateException.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\AckData.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\DataDictionaryUtils.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\ExtendableDataDictionary.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\FieldDef.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\FieldEncoding.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\FieldType.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Fields\IDataDictionary.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\GridCache.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\IncompatibilityException.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\AckMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\ControlOperation.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\DataDictionaryMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\DecodingException.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\Grid.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\GridColumn.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\IColumn.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\IStreamCompressor.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\IGridHeaderRegistry.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\HeartbeatMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\IStreamInflator.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\PriceStatusCodec.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\PriceSync.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\PriceSyncDecoder.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\PriceUpdateDecoder.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\SubscriptionSync.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\ISyncable.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\UncompressedStreamCompressor.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\ZlibStreamCompressor.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\ZlibStreamInflator.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\PixieProtocolOptions.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\PixieSubjectValidator.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\PixieVersion.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\SubjectSetRegister.cs" />
-    <Compile Include="src\Price\Subject\CommonComponents.cs" />
-    <Compile Include="src\Price\Subject\IComponentHandler.cs" />
-    <Compile Include="src\Price\Subject\IllegalSubjectException.cs" />
-    <Compile Include="src\Price\Subject\RequestSubjectComparator.cs" />
-    <Compile Include="src\Price\Subject\Subject.cs" />
-    <Compile Include="src\Price\Subject\SubjectBuilder.cs" />
-    <Compile Include="src\Price\Subject\SubjectComponent.cs" />
-    <Compile Include="src\Price\Subject\SubjectComponentName.cs" />
-    <Compile Include="src\Price\Subject\SubjectFormatter.cs" />
-    <Compile Include="src\Price\Subject\CommonSubjects.cs" />
-    <Compile Include="src\Price\Subject\SubjectIterator.cs" />
-    <Compile Include="src\Price\Subject\SubjectPart.cs" />
-    <Compile Include="src\Price\Subject\SubjectUtils.cs" />
-    <Compile Include="src\Price\Subject\SubjectValidator.cs" />
-    <Compile Include="src\Price\Subscription.cs" />
-    <Compile Include="src\Price\SubscriptionSet.cs" />
-    <Compile Include="src\PublicApi.cs" />
-    <Compile Include="src\Price\FieldName.cs" />
-    <Compile Include="src\Price\IBackground.cs" />
-    <Compile Include="src\Price\IBulkSubscriber.cs" />
-    <Compile Include="src\Price\IApiEventHandler.cs" />
-    <Compile Include="src\Price\IPriceField.cs" />
-    <Compile Include="src\Price\IPriceMap.cs" />
-    <Compile Include="src\Price\IProviderPlugin.cs" />
-    <Compile Include="src\Price\IProviderProperties.cs" />
-    <Compile Include="src\Price\ISession.cs" />
-    <Compile Include="src\Price\ISubscriber.cs" />
-    <Compile Include="src\Price\PriceManager.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\GrantMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\IOutgoingPixieMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\LoginMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\PixieMessageType.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\Messages\WelcomeMessage.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\PixieConnection.cs" />
-    <Compile Include="src\Price\Plugin\Pixie\PixieProviderPlugin.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\FieldExtractor.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\LoginEncryption.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\MessageFormatter.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PriceAdaptor.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinConnection.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinElement.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinMessageReader.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinProviderPlugin.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinSyntaxException.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinTagName.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\PuffinToken.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\TokenDictionary.cs" />
-    <Compile Include="src\Price\Plugin\Puffin\TokenType.cs" />
-    <Compile Include="src\Price\PriceMap.cs" />
-    <Compile Include="src\Price\PriceUpdateEvent.cs" />
-    <Compile Include="src\Price\ProviderProperties.cs" />
-    <Compile Include="src\Price\ProviderStatus.cs" />
-    <Compile Include="src\Price\ProviderStatusEvent.cs" />
-    <Compile Include="src\Price\SubscriptionStatus.cs" />
-    <Compile Include="src\Price\SubscriptionStatusEvent.cs" />
-    <Compile Include="src\Price\Tick.cs" />
-    <Compile Include="src\Price\ValueParser.cs" />
-    <Compile Include="src\Tools\AtomicBoolean.cs" />
-    <Compile Include="src\Tools\BitSetter.cs" />
-    <Compile Include="src\Tools\ByteBuffer.cs" />
-    <Compile Include="src\Tools\ConnectionTools.cs" />
-    <Compile Include="src\Tools\DateFormatter.cs" />
-    <Compile Include="src\Tools\GUID.cs" />
-    <Compile Include="src\Tools\JavaTime.cs" />
-    <Compile Include="src\Tools\NameCache.cs" />
-    <Compile Include="src\Tools\NumericCharacterEntity.cs" />
-    <Compile Include="src\Tools\Params.cs" />
-    <Compile Include="src\Tools\ServiceProperties.cs" />
-    <Compile Include="src\Tools\StreamReaderHelper.cs" />
-    <Compile Include="src\Tools\StringCharIterator.cs" />
-    <Compile Include="src\Tools\TimeFieldTools.cs" />
-    <Compile Include="src\Tools\TunnelException.cs" />
-    <Compile Include="src\Tools\Varint.cs" />
-    <Compile Include="src\Trade\Instruction\OrderAmend.cs" />
-    <Compile Include="src\Trade\Instruction\OrderAmendBuilder.cs" />
-    <Compile Include="src\Trade\Instruction\OrderCancel.cs" />
-    <Compile Include="src\Trade\Instruction\OrderCancelBuilder.cs" />
-    <Compile Include="src\Trade\Instruction\OrderInstruction.cs" />
-    <Compile Include="src\Trade\Instruction\OrderInstructionBuilder.cs" />
-    <Compile Include="src\Trade\Instruction\OrderSubmit.cs" />
-    <Compile Include="src\Trade\Instruction\OrderSubmitBuilder.cs" />
-    <Compile Include="src\Trade\Order\Algo.cs" />
-    <Compile Include="src\Trade\Order\AlgoBuilder.cs" />
-    <Compile Include="src\Trade\Order\Allocation.cs" />
-    <Compile Include="src\Trade\Order\AllocationBuilder.cs" />
-    <Compile Include="src\Trade\Order\AllocationTemplateEntry.cs" />
-    <Compile Include="src\Trade\Order\AllocationTemplateEntryBuilder.cs" />
-    <Compile Include="src\Trade\Order\Error.cs" />
-    <Compile Include="src\Trade\Order\Execution.cs" />
-    <Compile Include="src\Trade\Order\FutureOrder.cs" />
-    <Compile Include="src\Trade\Order\FutureOrderBuilder.cs" />
-    <Compile Include="src\Trade\Order\FxOrder.cs" />
-    <Compile Include="src\Trade\Order\FxOrderBuilder.cs" />
-    <Compile Include="src\Trade\Order\Order.cs" />
-    <Compile Include="src\Trade\Order\OrderBuilder.cs" />
-    <Compile Include="src\Trade\Rest\IRESTCallback.cs" />
-    <Compile Include="src\Trade\Rest\Json\JsonException.cs" />
-    <Compile Include="src\Trade\Rest\Json\JsonMarshaller.cs" />
-    <Compile Include="src\Trade\Rest\Json\IJsonMarshallable.cs" />
-    <Compile Include="src\Trade\Rest\RESTClient.cs" />
-    <Compile Include="src\Trade\SettlementDateResponse.cs" />
-    <Compile Include="src\Trade\TradeSession.cs" />
-    <Compile Include="src\UserInfo.cs" />
+    <Reference Include="Ionic.Zlib, Version=1.9.1.5, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
+      <HintPath>bin\Debug\Ionic.Zlib.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\scripts\release.sh">
@@ -216,37 +54,5 @@
     </Content>
     <Content Include="Ionic.Zlib.dll" />
     <None Include="obfuscar.xml" />
-    <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Obfuscar">
-      <Version>2.2.12</Version>
-    </PackageReference>
-    <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
-      "$(Obfuscar)" "..\..\obfuscar.xml"
-      mkdir "..\BidFX.Public.API"
-      copy "..\Obfuscator_Output\BidFX.Public.API.dll" "..\BidFX.Public.API\BidFX.Public.API.dll" /Y
-      copy "DotNetZip.dll" "..\BidFX.Public.API\DotNetZip.dll" /Y
-      copy "Serilog.dll" "..\BidFX.Public.API\Serilog.dll" /Y
-      )</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/BidFX.Public.API/Properties/AssemblyInfo.cs
+++ b/BidFX.Public.API/Properties/AssemblyInfo.cs
@@ -1,21 +1,6 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyVersion("1.7.3")]
-[assembly: AssemblyFileVersion("1.7.3")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyCompany("BidFX Limited")]
-[assembly: AssemblyTitle("BidFX.Public.API")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("BidFX.Public.API")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Allow internals visibile to tests
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/BidFX.Public.API/packages.config
+++ b/BidFX.Public.API/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DotNetZip" version="1.10.1" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
-  <package id="Obfuscar" version="2.2.12" targetFramework="net40" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
This conversion is necessary to target .NET Standard or .NET Core. Note: `LoginMessageTest`s fail until #4 is merged.